### PR TITLE
fix poerty.lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -238,7 +238,7 @@ soupsieve = [
 tls-client = [
     {file = "tls_client-0.1.5-py3-none-any.whl", hash = "sha256:cd65d7b1405cd2075050fca4e59abc6e04207b29ea47eabc6f406ce16735421f"},
 ]
-urllib3 = [poetry config experimental.new-installer false
+urllib3 = [
     {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},
     {file = "urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"},
 ]


### PR DESCRIPTION
when executing poetry install: I got
Unable to read the lock file (Invalid TOML file /Users/aeroxi/projects/wechat-chatgpt/poetry.lock: Unexpected character: 'p' at line 242 col 4). I believe there is a typo in poetry.lock
So I removed this line.