### PR TITLE
Fix: nonsense talking to Wechat Team

### DIFF
--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -126,7 +126,7 @@ export class ChatGPTBot {
   }
   async onMessage(message: Message) {
     const talker = message.talker();
-    if (talker.self() || message.type() > 10) {
+    if (talker.self() || message.type() > 10 || talker.name() == "微信团队") {
       return;
     }
     const text = message.text();


### PR DESCRIPTION
When the bot account login to a new device (in particular as a stateless container inside the pod with each restart), the Wechat Team will send a notification message, which results in persistent nonsense talking between the bot and Wechat Team.

This PR checks the talker's name and keeps silent when it is "微信团队".