### PR TITLE
reduce the size of docker image by deleting cache files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM python:3
 WORKDIR /app
 ARG POETRY_VERSION=1.2.2
-RUN apt-get update &&\
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - &&\
-    apt-get install -y nodejs &&\
-    pip3 install poetry
+RUN apt-get update && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/cache/apk/* && \
+    pip3 install --no-cache-dir poetry && \
+    rm -rf ~/.cache/
 COPY package*.json ./
 COPY pyproject.toml ./
 COPY poetry.lock ./
 # Install dependencies
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN poetry install && npm install
+RUN poetry install && rm -rf ~/.cache/ && npm install && rm -rf ~/.npm/
 COPY . .
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
the size of docker image will be reduced from 1.55GB to 1.32GB