### PR TITLE
fix: add `MessageType ` and support pnpm install.

### DIFF
--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -1,6 +1,5 @@
 import { ChatGPTAPI, ChatGPTConversation } from "chatgpt";
 import { Message } from "wechaty";
-import { MessageType } from "wechaty-puppet/src/schemas/message";
 import { config } from "./config.js";
 import { execa } from "execa";
 import { Cache } from "./cache.js";
@@ -12,6 +11,28 @@ import {
   isAccountWithUserInfo,
   isAccountWithSessionToken,
 } from "./interface.js";
+
+enum MessageType {
+  Unknown = 0,
+
+  Attachment = 1,    // Attach(6),
+  Audio = 2,    // Audio(1), Voice(34)
+  Contact = 3,    // ShareCard(42)
+  ChatHistory = 4,    // ChatHistory(19)
+  Emoticon = 5,    // Sticker: Emoticon(15), Emoticon(47)
+  Image = 6,    // Img(2), Image(3)
+  Text = 7,    // Text(1)
+  Location = 8,    // Location(48)
+  MiniProgram = 9,    // MiniProgram(33)
+  GroupNote = 10,   // GroupNote(53)
+  Transfer = 11,   // Transfers(2000)
+  RedEnvelope = 12,   // RedEnvelopes(2001)
+  Recalled = 13,   // Recalled(10002)
+  Url = 14,   // Url(5)
+  Video = 15,   // Video(4), Video(43)
+  Post = 16,   // Moment, Channel, Tweet, etc
+}
+
 const SINGLE_MESSAGE_MAX_SIZE = 500;
 const ErrorCode2Message: Record<string, string> = {
   "503":
@@ -201,7 +222,7 @@ export class ChatGPTBot {
   ): boolean {
     return (
       talker.self() ||
-      messageType > 10 ||
+      messageType > MessageType.GroupNote ||
       talker.name() == "微信团队" ||
       // 语音(视频)消息
       text.includes("收到一条视频/语音聊天消息，请在手机上查看") ||


### PR DESCRIPTION
When installed using pnpm:

src/chatgpt.ts:3:29 - error TS2307: Cannot find module 'wechaty-puppet/src/schemas/message' or its corresponding type declarations.