### PR TITLE
解决机器人回复英文而不是中文的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ COPY pyproject.toml ./
 COPY poetry.lock ./
 # Install dependencies
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN poetry add git+https://github.com/suzhiba/ChatGPT.git@main
-
+RUN poetry add git+https://github.com/suzhiba/ChatGPT.git@suzhiba/add_defualt_language_option
 RUN poetry install && npm install && rm -rf ~/.npm/
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update && \
     rm -rf ~/.cache/
 COPY package*.json ./
 COPY pyproject.toml ./
-COPY poetry.lock ./
 # Install dependencies
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+RUN poetry add git+https://github.com/suzhiba/ChatGPT.git@main
+
 RUN poetry install && npm install && rm -rf ~/.npm/
+
 COPY . .
 CMD ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     rm -rf ~/.cache/
 COPY package*.json ./
 COPY pyproject.toml ./
+COPY poetry.lock ./
 # Install dependencies
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN poetry add git+https://github.com/suzhiba/ChatGPT.git@main

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ English | [中文文档](README_ZH.md)
 - [ ] Add sendmessage retry for 429/503
 
 ## build Docker
-docker build -t suzhiba:wechat .
+```sh
+# build chinese langeuage version
+docker build -t holegots/wechat-chatgpt:chinese .
+```
 
 ## Use with docker in Linux(recommended)
 
@@ -35,7 +38,7 @@ docker build -t suzhiba:wechat .
 cp config.yaml.example config.yaml
 # Change Config.yaml
 # run docker command in Linux or WindowsPowerShell
-docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml suzhiba:wechat
+docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
 # login with qrcode
 docker logs -f wechat-chatgpt
 ```
@@ -45,9 +48,9 @@ docker logs -f wechat-chatgpt
 ```sh
 # Create and modify config.yaml in the current directory
 # run docker command in WindowsPowerShell
-docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml suzhiba:wechat
+docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
 # In the Windows command line (cmd) environment, you may mount the current directory like this:
-docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml suzhiba:wechat
+docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
 # login with qrcode
 docker logs -f wechat-chatgpt
 ```
@@ -59,9 +62,9 @@ docker pull holegots/wechat-chatgpt:latest
 docker stop wechat-chatgpt
 docker rm wechat-chatgpt
 # run docker command in Linux or WindowsPowerShell
-docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml suzhiba:wechat
+docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
 # In the Windows command line (cmd) environment, you may mount the current directory like this:
-docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml suzhiba:wechat
+docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
 # login with qrcode
 docker logs -f wechat-chatgpt
 ```

--- a/README.md
+++ b/README.md
@@ -26,13 +26,16 @@ English | [中文文档](README_ZH.md)
 - [x] Auto Reload OpenAI Accounts Pool
 - [ ] Add sendmessage retry for 429/503
 
+## build Docker
+docker build -t suzhiba:wechat .
+
 ## Use with docker in Linux(recommended)
 
 ```sh
 cp config.yaml.example config.yaml
 # Change Config.yaml
 # run docker command in Linux or WindowsPowerShell
-docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
+docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml suzhiba:wechat
 # login with qrcode
 docker logs -f wechat-chatgpt
 ```
@@ -42,9 +45,9 @@ docker logs -f wechat-chatgpt
 ```sh
 # Create and modify config.yaml in the current directory
 # run docker command in WindowsPowerShell
-docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
+docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml suzhiba:wechat
 # In the Windows command line (cmd) environment, you may mount the current directory like this:
-docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
+docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml suzhiba:wechat
 # login with qrcode
 docker logs -f wechat-chatgpt
 ```
@@ -56,9 +59,9 @@ docker pull holegots/wechat-chatgpt:latest
 docker stop wechat-chatgpt
 docker rm wechat-chatgpt
 # run docker command in Linux or WindowsPowerShell
-docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
+docker run -d --name wechat-chatgpt -v $(pwd)/config.yaml:/app/config.yaml suzhiba:wechat
 # In the Windows command line (cmd) environment, you may mount the current directory like this:
-docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml holegots/wechat-chatgpt:latest
+docker run -d --name wechat-chatgpt -v %cd%/config.yaml:/app/config.yaml suzhiba:wechat
 # login with qrcode
 docker logs -f wechat-chatgpt
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -27,6 +27,12 @@
 - [x] 实现 OpenAI 账户池的热加载
 - [ ] 当 OpenAI 返回码为 429/503 时自动重试
 
+## 构造支持中文的镜像。
+```sh
+# 构建中文版镜像
+docker build -t holegots/wechat-chatgpt:chinese .
+```
+
 ## 在Linux上通过Docker使用（✅ 推荐）
 
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["Holegots <fuergaosi@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-revchatgpt = "^0.0.33.5"
 [tool.poetry.dev-dependencies]
 
 [build-system]


### PR DESCRIPTION
官方的revchatgpt默认调用为英文版本，我fork了分支出来，改为默认中文，目前通过build镜像可用中文。我在沟通revchatgpt的维护者，希望加入中文配置功能，等到官方支持中文后，可以切回官方分支。
更新相关：
* 删除原revchatgpt在pyproject.toml的配置
* 在Dockerfile中增加对中文版本revchatgpt的引用。