### PR TITLE
fix: tigger command in room

### DIFF
--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -274,7 +274,7 @@ export class ChatGPTBot {
       ""
     );
     // remove more text via - - - - - - - - - - - - - - -
-    return text;
+    return text.trim();
   }
   async getGPTMessage(text: string, talkerId: string): Promise<string> {
     return await this.chatGPTPool.sendMessage(text, talkerId);


### PR DESCRIPTION
群聊时输入的command经过替换后会多一个空格，比如`' /reset’`、` /help`，然后不能解析为命令

![image](https://user-images.githubusercontent.com/20984074/206896957-93eed92a-ed56-4083-86ee-95dcc2c2253d.png)

 `text.trim()`一下就好了，我觉得在这边处理应该合适，去掉前后空格应该没什么问题吧

![image](https://user-images.githubusercontent.com/20984074/206897043-a88d4f9d-2d81-4ee9-bdd3-afdb561bab12.png)
