### PR TITLE
support self-ask in private message

### DIFF
--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -318,7 +318,7 @@ export class ChatGPTBot {
     text: string
   ): boolean {
     return (
-      talker.self() ||
+      // talker.self() ||
       messageType > MessageType.GroupNote ||
       talker.name() == "微信团队" ||
       // 语音(视频)消息
@@ -358,7 +358,8 @@ export class ChatGPTBot {
     if (this.tiggerGPTMessage(rawText, privateChat)) {
       const text = this.cleanMessage(rawText, privateChat);
       if (privateChat) {
-        return await this.onPrivateMessage(talker, text);
+        let receiver = (talker.self() ? message.listener() : talker) || talker;
+        return await this.onPrivateMessage(receiver, text);
       } else {
         return await this.onGroupMessage(talker, text, room);
       }

--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -318,7 +318,7 @@ export class ChatGPTBot {
     text: string
   ): boolean {
     return (
-      // talker.self() ||
+      (talker.self() && messageType != MessageType.Text) ||
       messageType > MessageType.GroupNote ||
       talker.name() == "微信团队" ||
       // 语音(视频)消息


### PR DESCRIPTION
我朋友只有一个微信号，他想把自己的微信作为 ChatGPT 机器人使用。在与别人私聊的对话中，他希望自己也可以通过触发关键词来向 ChatGPT 提问。因此做了以下的改动，私以为对于没有多余微信号的使用者还是有点用的。

- `isNonsense` 过滤中忽略了 talker 是 self 的情况
- 如果 talker 是 self 则 say 的对象为 listener。（为了保证类型后面加了 ` || talker`）