### PR TITLE
Upgrade chatgpt dependency to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
   "license": "ISC",
   "dependencies": {
     "async-retry": "^1.3.3",
-    "chatgpt": "^4.0.4",
+    "chatgpt": "^4.1.1",
     "dotenv": "^16.0.3",
     "execa": "^6.1.0",
     "qrcode": "^1.5.1",
     "uuid": "^9.0.0",
     "wechaty": "^1.20.2",
     "wechaty-puppet-wechat": "^1.18.4",
-    "yaml": "^2.1.3"
+    "yaml": "^2.1.3",
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.5",


### PR DESCRIPTION
* Upgrade chatgpt dependency to 4.1.1 which use a smarter model
* Add a dependency of typescript for running outside docker