### PR TITLE
Create public directory to save audio messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,5 +322,3 @@ config.yaml
 .vscode
 
 data/
-
-public/

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
create `public` directory to fix error `no such file or directory, open '/app/public/6446491591471262325.mp3'` when saving audio message in 
```
      let fileName = "./public/" + fileBox.name;
      await fileBox.toFile(fileName, true).catch((e) => {
        console.log("保存语音失败",e);
        return;
      });
``` 
resolve #816 