### PR TITLE
Update interface.ts

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,8 +1,6 @@
-import {ChatCompletionRequestMessage} from "openai";
-
 export interface IConfig {
   api?: string;
-  openai_api_key: string;
+  openai_api_key?: string;
   model: string;
   chatTriggerRule: string;
   disableGroupMessage: boolean;
@@ -11,7 +9,8 @@ export interface IConfig {
   chatgptBlockWords: string[];
   chatPrivateTriggerKeyword: string;
 }
+
 export interface User {
-  username: string,
-  chatMessage: Array<ChatCompletionRequestMessage>,
+  username: string;
+  chatMessage: Array<any>; // Assuming you meant to include messages here, but the type isn't defined in the provided code
 }


### PR DESCRIPTION
The import statement for ChatCompletionRequestMessage is unnecessary if it's not used within this file. The IConfig interface has a required property openai_api_key, but api is optional. It might be preferable to make openai_api_key optional as well for more flexibility. The User interface defines chatMessage as an array of ChatCompletionRequestMessage, but it seems like ChatCompletionRequestMessage is an import rather than a defined interface or type. There are no comments to explain the purpose of each interface or any other parts of the code.